### PR TITLE
remove .exe from exestrip

### DIFF
--- a/conf/exestrip
+++ b/conf/exestrip
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-for FILE in $*
+for FILE in $
 do
-   strip $FILE.exe
+   strip $FILE
 done


### PR DESCRIPTION
(cygwin) exestrip is called with a list of executables, but then adds .exe to the filenames. The result is XXX.exe.exe, which is never found.